### PR TITLE
Fix mobile share file

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,7 +86,7 @@ var buildShareFile = function buildShareFile(_ref3) {
       startDatetime = _ref3.startDatetime,
       title = _ref3.title;
   var content = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'BEGIN:VEVENT', "URL:".concat(document.URL), "DTSTART:".concat(startDatetime), "DTEND:".concat(endDatetime), "SUMMARY:".concat(title), "DESCRIPTION:".concat(description), "LOCATION:".concat(location), 'END:VEVENT', 'END:VCALENDAR'].join('\n');
-  return isMobile() ? "data:text/calendar;charset=utf8".concat(content) : content;
+  return isMobile() ? "data:text/calendar;charset=utf8,".concat(content) : content;
 };
 /**
  * Takes an event object and a type of URL and returns either a calendar event

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,7 +86,7 @@ var buildShareFile = function buildShareFile(_ref3) {
       startDatetime = _ref3.startDatetime,
       title = _ref3.title;
   var content = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'BEGIN:VEVENT', "URL:".concat(document.URL), "DTSTART:".concat(startDatetime), "DTEND:".concat(endDatetime), "SUMMARY:".concat(title), "DESCRIPTION:".concat(description), "LOCATION:".concat(location), 'END:VEVENT', 'END:VCALENDAR'].join('\n');
-  return isMobile() ? "data:text/calendar;charset=utf8,".concat(content) : content;
+  return isMobile() ? encodeURI("data:text/calendar;charset=utf8,".concat(content)) : content;
 };
 /**
  * Takes an event object and a type of URL and returns either a calendar event

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -40,6 +40,6 @@ describe('buildShareUrl', function () {
     });
 
     var result = (0, _utils.buildShareUrl)(testEvent, _enums.SHARE_SITES.ICAL);
-    expect(result).toEqual('data:text/calendar;charset=utf8BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR');
+    expect(result).toEqual(encodeURI('data:text/calendar;charset=utf8,BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR'));
   });
 });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -87,7 +87,7 @@ const buildShareFile = ({
     'END:VCALENDAR',
   ].join('\n');
 
-  return isMobile() ? `data:text/calendar;charset=utf8,${content}` : content;
+  return isMobile() ? encodeURI(`data:text/calendar;charset=utf8,${content}`) : content;
 }
 
 /**

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -87,7 +87,7 @@ const buildShareFile = ({
     'END:VCALENDAR',
   ].join('\n');
 
-  return isMobile() ? `data:text/calendar;charset=utf8${content}` : content;
+  return isMobile() ? `data:text/calendar;charset=utf8,${content}` : content;
 }
 
 /**

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -39,6 +39,6 @@ describe('buildShareUrl', () => {
     });
 
     const result = buildShareUrl(testEvent, SHARE_SITES.ICAL);
-    expect(result).toEqual('data:text/calendar;charset=utf8BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR');
+    expect(result).toEqual(encodeURI('data:text/calendar;charset=utf8,BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR'));
   });
 });


### PR DESCRIPTION
On iOS, we were unable to add calendar files to Calendar while using Safari, so added a comma and encoded the share file string.