### PR TITLE
Disable URI encode for Outlook

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -105,7 +105,7 @@ export const buildShareUrl = (
   { description, duration, endDatetime, location, startDatetime, title },
   type,
 ) => {
-  const encodeURI = type !== SHARE_SITES.ICAL;
+  const encodeURI = type !== SHARE_SITES.ICAL && type !== SHARE_SITES.OUTLOOK;
 
   const data = {
     description: encodeURI ? encodeURIComponent(description) : description,


### PR DESCRIPTION
Outlook (desktop) shows special chars currently because it's being encoded. I realize this makes the ics and outlook options totally identical though so this might be more of a conversation starter than an actual PR worth merging. 🤷‍♂️ 

Example:
Title: "This is a title"
Result: "This%20is%20a%20title"