### PR TITLE
Move PropTypes to Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "react": "^15.3.0 || ^16.2.0",
     "react-dom": "^15.3.0 || ^16.2.0"
   },
+  "dependencies": {
+    "prop-types": "^15.6.2"
+  },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.46",
     "@babel/core": "^7.0.0-beta.49",
@@ -36,7 +39,6 @@
     "html-webpack-plugin": "^3.2.0",
     "jest": "^23.1.0",
     "moment": "^2.22.2",
-    "prop-types": "^15.6.2",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "react-highlight": "^0.12.0",
@@ -53,6 +55,5 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:jasonleibowitz/react-add-to-calendar-hoc.git"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
Per the facebook/prop-types [readme](https://github.com/facebook/prop-types#how-to-depend-on-this-package), prop-types should be declared in dependencies, not dev dependencies or peer dependencies. This might fix some issues with bundlephobia and npm runkit not recognizing the repo. 