### PR TITLE
Minor tweaks + iOS compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,7 +82,7 @@ function AddToCalendar(WrappedButton, WrappedDropdown) {
           link.click();
           document.body.removeChild(link);
         } else {
-          window.open(url, '_blank');
+          window.open(url, '_self');
         }
       }), _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "handleDropdownToggle", function (e) {
         e.preventDefault();

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,13 +75,21 @@ function AddToCalendar(WrappedButton, WrappedDropdown) {
           var blob = new Blob([url], {
             type: 'text/calendar;charset=utf-8'
           });
-          var link = document.createElement('a');
-          link.href = window.URL.createObjectURL(blob);
-          link.setAttribute('download', filename);
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
+
+          if ((0, _utils.isInternetExplorer)()) {
+            // IE 11 approach
+            window.navigator.msSaveOrOpenBlob(blob, filename);
+          } else {
+            var link = document.createElement('a');
+            link.href = window.URL.createObjectURL(blob);
+            link.setAttribute('download', filename);
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+          }
         } else {
+          // Mobile download
+          // _self = iOS compatible. Android supports either _self or _blank it seems.
           window.open(url, '_self');
         }
       }), _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "handleDropdownToggle", function (e) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,10 +82,11 @@ var yahooShareUrl = function yahooShareUrl(_ref2) {
 var buildShareFile = function buildShareFile(_ref3) {
   var description = _ref3.description,
       endDatetime = _ref3.endDatetime,
-      location = _ref3.location,
+      _ref3$location = _ref3.location,
+      location = _ref3$location === void 0 ? '' : _ref3$location,
       startDatetime = _ref3.startDatetime,
       title = _ref3.title;
-  var content = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'BEGIN:VEVENT', "URL:".concat(document.URL), "DTSTART:".concat(startDatetime), "DTEND:".concat(endDatetime), "SUMMARY:".concat(title), "DESCRIPTION:".concat(description), "LOCATION:".concat(location), 'END:VEVENT', 'END:VCALENDAR'].join('\n');
+  var content = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'BEGIN:VEVENT', "URL:".concat(document.URL), "METHOD:PUBLISH", "DTSTART:".concat(startDatetime), "DTEND:".concat(endDatetime), "SUMMARY:".concat(title), "DESCRIPTION:".concat(description), "LOCATION:".concat(location), 'END:VEVENT', 'END:VCALENDAR'].join('\n');
   return isMobile() ? encodeURI("data:text/calendar;charset=utf8,".concat(content)) : content;
 };
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.buildShareUrl = exports.isMobile = exports.formatDate = void 0;
+exports.buildShareUrl = exports.isMobile = exports.isInternetExplorer = exports.formatDate = void 0;
 
 var _enums = require("./enums");
 
@@ -17,13 +17,23 @@ var formatDate = function formatDate(date) {
   return date && date.replace('+00:00', 'Z');
 };
 /**
+ * Lets you know if msSaveOrOpenBlob should be used to download the ical file
+ */
+
+
+exports.formatDate = formatDate;
+
+var isInternetExplorer = function isInternetExplorer() {
+  return window.navigator && window.navigator.msSaveOrOpenBlob && window.Blob;
+};
+/**
  * Tests provided UserAgent against Known Mobile User Agents
  * @param {string} userAgent
  * @returns {bool} isMobileDevice
  */
 
 
-exports.formatDate = formatDate;
+exports.isInternetExplorer = isInternetExplorer;
 
 var isMobile = function isMobile() {
   return /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/.test(window.navigator.userAgent || window.navigator.vendor || window.opera);

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { SHARE_SITES } from './enums';
-import { buildShareUrl, formatDate } from './utils';
+import { buildShareUrl, formatDate, isInternetExplorer } from './utils';
 
 export { SHARE_SITES };
 export default function AddToCalendar(WrappedButton, WrappedDropdown) {
@@ -43,13 +43,20 @@ export default function AddToCalendar(WrappedButton, WrappedDropdown) {
         const filename = 'download.ics';
         const blob = new Blob([url], { type: 'text/calendar;charset=utf-8' });
 
-        const link = document.createElement('a');
-        link.href = window.URL.createObjectURL(blob);
-        link.setAttribute('download', filename);
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        if (isInternetExplorer()) {
+          // IE 11 approach
+          window.navigator.msSaveOrOpenBlob(blob, filename);
+        } else {
+          const link = document.createElement('a');
+          link.href = window.URL.createObjectURL(blob);
+          link.setAttribute('download', filename);
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        }
       } else {
+        // Mobile download
+        // _self = iOS compatible. Android supports either _self or _blank it seems.
         window.open(url, '_self');
       }
     };

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -17,10 +17,10 @@ export default function AddToCalendar(WrappedButton, WrappedDropdown) {
         endDatetime: PropTypes.string,
         location: PropTypes.string,
         startDatetime: PropTypes.string,
-        title: PropTypes.string,
+        title: PropTypes.string
       }).isRequired,
       items: PropTypes.arrayOf(PropTypes.oneOf(Object.values(SHARE_SITES))),
-      linkProps: PropTypes.shape(),
+      linkProps: PropTypes.shape()
     };
 
     static defaultProps = {
@@ -29,14 +29,14 @@ export default function AddToCalendar(WrappedButton, WrappedDropdown) {
       className: null,
       dropdownProps: {},
       items: Object.values(SHARE_SITES),
-      linkProps: {},
+      linkProps: {}
     };
 
     state = {
-      dropdownOpen: false,
+      dropdownOpen: false
     };
 
-    handleCalendarButtonClick = e => {
+    handleCalendarButtonClick = (e) => {
       e.preventDefault();
       const url = e.currentTarget.getAttribute('href');
       if (url.startsWith('BEGIN')) {
@@ -50,13 +50,13 @@ export default function AddToCalendar(WrappedButton, WrappedDropdown) {
         link.click();
         document.body.removeChild(link);
       } else {
-        window.open(url, '_blank');
+        window.open(url, '_self');
       }
     };
 
-    handleDropdownToggle = e => {
+    handleDropdownToggle = (e) => {
       e.preventDefault();
-      this.setState(prevState => ({ dropdownOpen: !prevState.dropdownOpen }));
+      this.setState((prevState) => ({ dropdownOpen: !prevState.dropdownOpen }));
     };
 
     render() {
@@ -64,30 +64,22 @@ export default function AddToCalendar(WrappedButton, WrappedDropdown) {
 
       return (
         <div className={className}>
-          <WrappedButton
-            {...buttonProps}
-            onClick={this.handleDropdownToggle}
-          >
+          <WrappedButton {...buttonProps} onClick={this.handleDropdownToggle}>
             {buttonText}
           </WrappedButton>
           {this.state.dropdownOpen && (
-              <WrappedDropdown
-                {...dropdownProps}
-                isOpen={this.state.dropdownOpen}
-                onRequestClose={this.handleDropdownToggle}
-              >
-                {items.map(item => (
-                  <a
-                    {...linkProps}
-                    key={item}
-                    onClick={this.handleCalendarButtonClick}
-                    href={buildShareUrl(event, item)}
-                  >
-                    {item}
-                  </a>
-                ))}
-              </WrappedDropdown>
-            )}
+            <WrappedDropdown
+              {...dropdownProps}
+              isOpen={this.state.dropdownOpen}
+              onRequestClose={this.handleDropdownToggle}
+            >
+              {items.map((item) => (
+                <a {...linkProps} key={item} onClick={this.handleCalendarButtonClick} href={buildShareUrl(event, item)}>
+                  {item}
+                </a>
+              ))}
+            </WrappedDropdown>
+          )}
         </div>
       );
     }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,21 +1,22 @@
 import { SHARE_SITES } from './enums';
 
-
 /**
  * Converts Date String with UTC timezone to date consumable by calendar
  * apps. Changes +00:00 to Z.
  * @param {string} Date in YYYYMMDDTHHmmssZ format
  * @returns {string} Date with +00:00 replaceed with Z
  */
-export const formatDate = date => date && date.replace('+00:00', 'Z');
-
+export const formatDate = (date) => date && date.replace('+00:00', 'Z');
 
 /**
  * Tests provided UserAgent against Known Mobile User Agents
  * @param {string} userAgent
  * @returns {bool} isMobileDevice
  */
-export const isMobile = () => /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/.test(window.navigator.userAgent || window.navigator.vendor || window.opera);
+export const isMobile = () =>
+  /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/.test(
+    window.navigator.userAgent || window.navigator.vendor || window.opera
+  );
 
 /**
  * Takes an event object and returns a Google Calendar Event URL
@@ -26,16 +27,8 @@ export const isMobile = () => /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile
  * @param {string} event.title
  * @returns {string} Google Calendar Event URL
  */
-const googleShareUrl = ({
-  description,
-  endDatetime,
-  location,
-  startDatetime,
-  title,
-}) =>
-  `https://calendar.google.com/calendar/render?action=TEMPLATE&dates=${
-    startDatetime
-  }/${endDatetime}&location=${location}&text=${title}&details=${description}`;
+const googleShareUrl = ({ description, endDatetime, location, startDatetime, title }) =>
+  `https://calendar.google.com/calendar/render?action=TEMPLATE&dates=${startDatetime}/${endDatetime}&location=${location}&text=${title}&details=${description}`;
 
 /**
  * Takes an event object and returns a Yahoo Calendar Event URL
@@ -46,16 +39,8 @@ const googleShareUrl = ({
  * @param {string} event.title
  * @returns {string} Yahoo Calendar Event URL
  */
-const yahooShareUrl = ({
-  description,
-  duration,
-  location,
-  startDatetime,
-  title,
-}) =>
-  `https://calendar.yahoo.com/?v=60&view=d&type=20&title=${title}&st=${
-    startDatetime
-  }&dur=${duration}&desc=${description}&in_loc=${location}`;
+const yahooShareUrl = ({ description, duration, location, startDatetime, title }) =>
+  `https://calendar.yahoo.com/?v=60&view=d&type=20&title=${title}&st=${startDatetime}&dur=${duration}&desc=${description}&in_loc=${location}`;
 
 /**
  * Takes an event object and returns an array to be downloaded as ics file
@@ -66,29 +51,24 @@ const yahooShareUrl = ({
  * @param {string} event.title
  * @returns {array} ICS Content
  */
-const buildShareFile = ({
-  description,
-  endDatetime,
-  location,
-  startDatetime,
-  title,
-}) => {
+const buildShareFile = ({ description, endDatetime, location = '', startDatetime, title }) => {
   let content = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
     'BEGIN:VEVENT',
     `URL:${document.URL}`,
+    `METHOD:PUBLISH`,
     `DTSTART:${startDatetime}`,
     `DTEND:${endDatetime}`,
     `SUMMARY:${title}`,
     `DESCRIPTION:${description}`,
     `LOCATION:${location}`,
     'END:VEVENT',
-    'END:VCALENDAR',
+    'END:VCALENDAR'
   ].join('\n');
 
   return isMobile() ? encodeURI(`data:text/calendar;charset=utf8,${content}`) : content;
-}
+};
 
 /**
  * Takes an event object and a type of URL and returns either a calendar event
@@ -101,10 +81,7 @@ const buildShareFile = ({
  * @param {string} event.title
  * @param {enum} type One of SHARE_SITES from ./enums
  */
-export const buildShareUrl = (
-  { description, duration, endDatetime, location, startDatetime, title },
-  type,
-) => {
+export const buildShareUrl = ({ description, duration, endDatetime, location, startDatetime, title }, type) => {
   const encodeURI = type !== SHARE_SITES.ICAL && type !== SHARE_SITES.OUTLOOK;
 
   const data = {
@@ -113,7 +90,7 @@ export const buildShareUrl = (
     endDatetime: formatDate(endDatetime),
     location: encodeURI ? encodeURIComponent(location) : location,
     startDatetime: formatDate(startDatetime),
-    title: encodeURI ? encodeURIComponent(title) : title,
+    title: encodeURI ? encodeURIComponent(title) : title
   };
 
   switch (type) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -9,6 +9,13 @@ import { SHARE_SITES } from './enums';
 export const formatDate = (date) => date && date.replace('+00:00', 'Z');
 
 /**
+ * Lets you know if msSaveOrOpenBlob should be used to download the ical file
+ */
+export const isInternetExplorer = () => {
+  return window.navigator && window.navigator.msSaveOrOpenBlob && window.Blob;
+};
+
+/**
  * Tests provided UserAgent against Known Mobile User Agents
  * @param {string} userAgent
  * @returns {bool} isMobileDevice

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -8,8 +8,8 @@ const testEvent = {
   endDatetime: '20150126T020000+00:00',
   location: 'NYC',
   startDatetime: '20150126T000000+00:00',
-  title: 'Super Fun Event',
-}
+  title: 'Super Fun Event'
+};
 
 describe('formatDate', () => {
   it('replaces +00:00 from a date string with Z', () => {
@@ -20,25 +20,35 @@ describe('formatDate', () => {
 describe('buildShareUrl', () => {
   it('returns a proper Google share URL', () => {
     const result = buildShareUrl(testEvent, SHARE_SITES.GOOGLE);
-    expect(result).toEqual('https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20150126T000000Z/20150126T020000Z&location=NYC&text=Super%20Fun%20Event&details=Description%20of%20event.%20Going%20to%20have%20a%20lot%20of%20fun%20doing%20things%20that%20we%20scheduled%20ahead%20of%20time.');
+    expect(result).toEqual(
+      'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20150126T000000Z/20150126T020000Z&location=NYC&text=Super%20Fun%20Event&details=Description%20of%20event.%20Going%20to%20have%20a%20lot%20of%20fun%20doing%20things%20that%20we%20scheduled%20ahead%20of%20time.'
+    );
   });
 
   it('returns a proper Yahoo share URL', () => {
     const result = buildShareUrl(testEvent, SHARE_SITES.YAHOO);
-    expect(result).toEqual('https://calendar.yahoo.com/?v=60&view=d&type=20&title=Super%20Fun%20Event&st=20150126T000000Z&dur=0200&desc=Description%20of%20event.%20Going%20to%20have%20a%20lot%20of%20fun%20doing%20things%20that%20we%20scheduled%20ahead%20of%20time.&in_loc=NYC')
+    expect(result).toEqual(
+      'https://calendar.yahoo.com/?v=60&view=d&type=20&title=Super%20Fun%20Event&st=20150126T000000Z&dur=0200&desc=Description%20of%20event.%20Going%20to%20have%20a%20lot%20of%20fun%20doing%20things%20that%20we%20scheduled%20ahead%20of%20time.&in_loc=NYC'
+    );
   });
 
   it('returns a proper iCal content object', () => {
     const result = buildShareUrl(testEvent, SHARE_SITES.ICAL);
-    expect(result).toEqual('BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR');
+    expect(result).toEqual(
+      'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR'
+    );
   });
 
   it('prepends a data URL when userAgent is mobile', () => {
-    navigator.__defineGetter__('userAgent', function(){
-      return "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
+    navigator.__defineGetter__('userAgent', function() {
+      return 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1';
     });
 
     const result = buildShareUrl(testEvent, SHARE_SITES.ICAL);
-    expect(result).toEqual(encodeURI('data:text/calendar;charset=utf8,BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR'));
+    expect(result).toEqual(
+      encodeURI(
+        'data:text/calendar;charset=utf8,BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nMETHOD:PUBLISH\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR'
+      )
+    );
   });
 });

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -35,7 +35,7 @@ describe('buildShareUrl', () => {
   it('returns a proper iCal content object', () => {
     const result = buildShareUrl(testEvent, SHARE_SITES.ICAL);
     expect(result).toEqual(
-      'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR'
+      'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:about:blank\nMETHOD:PUBLISH\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR'
     );
   });
 


### PR DESCRIPTION
- `location` is now an empty string if undefined. 
- Added `METHOD:PUBLISH` to iCal/Outlook.
- Open iCal/Outlook download in same tab in mobile. The new tab was causing the "Add to Calendar" dialog to close immediately in iOS (always in 11.3 for me, sometimes in 11.4 for other people I had testing). Tested across a few different iPhones, iPads, and Android phones at my company and it seems to be working properly now. 