### PR TITLE
Update buttonText proptype to a node

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,7 +133,7 @@ function AddToCalendar(WrappedButton, WrappedDropdown) {
     return AddToCalendarWrapped;
   }(_react.Component), _defineProperty(_class, "propTypes", {
     buttonProps: _propTypes.default.shape(),
-    buttonText: _propTypes.default.string,
+    buttonText: _propTypes.default.node,
     className: _propTypes.default.string,
     dropdownProps: _propTypes.default.shape(),
     event: _propTypes.default.shape({

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -8,7 +8,7 @@ export default function AddToCalendar(WrappedButton, WrappedDropdown) {
   return class AddToCalendarWrapped extends Component {
     static propTypes = {
       buttonProps: PropTypes.shape(),
-      buttonText: PropTypes.string,
+      buttonText: PropTypes.node,
       className: PropTypes.string,
       dropdownProps: PropTypes.shape(),
       event: PropTypes.shape({


### PR DESCRIPTION
Allow rendering of any renderable React node rather than limit it to a string. I.e, this will allow for rendering other react components within the button, icons, etc.... 