### PR TITLE
fix: escape ics multiline descriptions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,6 +94,18 @@ var yahooShareUrl = function yahooShareUrl(_ref2) {
       title = _ref2.title;
   return "https://calendar.yahoo.com/?v=60&view=d&type=20&title=".concat(title, "&st=").concat(startDatetime, "&dur=").concat(duration, "&desc=").concat(description, "&in_loc=").concat(location);
 };
+
+/**
+ * Takes a multiline description field string and escapes newlines as literal \\n characters for ICS previews
+ *
+ * @param {string} description
+ * @returns {string} ics-compatible multiline string file
+ */
+
+var escapeICSDescription = function escapeICSDescription(description) {
+  return description.replace(/(\r?\n|<br\/? ?>)/g, '\\n');
+};
+
 /**
  * Takes an event object and returns an array to be downloaded as ics file
  * @param {string} event.description
@@ -107,7 +119,7 @@ var yahooShareUrl = function yahooShareUrl(_ref2) {
 
 var buildShareFile = function buildShareFile(_ref3) {
   var _ref3$description = _ref3.description,
-      description = _ref3$description === void 0 ? '' : _ref3$description,
+      description = escapeICSDescription(_ref3$description === void 0 ? '' : _ref3$description),
       _ref3$ctz = _ref3.ctz,
       ctz = _ref3$ctz === void 0 ? '' : _ref3$ctz,
       endDatetime = _ref3.endDatetime,


### PR DESCRIPTION
Simple proposed fix for https://github.com/jasonleibowitz/react-add-to-calendar-hoc/issues/33 - with a little bit of regexing, we can take newlines (optionally windows style with CRLF) and html `<br>` tags (optionally with a closing `/`) and replace them with literal `\n` characters that the calendar apps expect for newlines.

Tested an example ics file in both Windows Outlook and macOS Calendar