### PR TITLE
Allow adding optional VTIMEZONE component to ICS files

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,14 @@ exports.buildShareUrl = exports.escapeICSDescription = exports.isInternetExplore
 
 var _enums = require("./enums");
 
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
 /**
  * Converts Date String with UTC timezone to date consumable by calendar
  * apps. Changes +00:00 to Z.
@@ -122,11 +130,14 @@ var buildShareFile = function buildShareFile(_ref3) {
       startDatetime = _ref3.startDatetime,
       _ref3$timezone = _ref3.timezone,
       timezone = _ref3$timezone === void 0 ? '' : _ref3$timezone,
+      _ref3$vtimezone = _ref3.vtimezone,
+      vtimezone = _ref3$vtimezone === void 0 ? '' : _ref3$vtimezone,
       _ref3$title = _ref3.title,
       title = _ref3$title === void 0 ? '' : _ref3$title;
-  var content = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'BEGIN:VEVENT', "URL:".concat(document.URL), 'METHOD:PUBLISH', // TODO: Will need to parse the date without Z for ics
+  var vtimezoneTrimmed = vtimezone && vtimezone.replace(/^\s+/, '').replace(/\s+$/, '');
+  var content = ['BEGIN:VCALENDAR', 'VERSION:2.0'].concat(_toConsumableArray(vtimezoneTrimmed ? [vtimezoneTrimmed] : []), ['BEGIN:VEVENT', "URL:".concat(document.URL), 'METHOD:PUBLISH', // TODO: Will need to parse the date without Z for ics
   // This means I'll probably have to require a date lib - luxon most likely or datefns
-  timezone === '' ? "DTSTART:".concat(startDatetime) : "DTSTART;TZID=".concat(timezone, ":").concat(startDatetime), timezone === '' ? "DTEND:".concat(endDatetime) : "DTEND;TZID=".concat(timezone, ":").concat(endDatetime), "SUMMARY:".concat(title), "DESCRIPTION:".concat(escapeICSDescription(description)), "LOCATION:".concat(location), 'END:VEVENT', 'END:VCALENDAR'].join('\n');
+  timezone === '' ? "DTSTART:".concat(startDatetime) : "DTSTART;TZID=".concat(timezone, ":").concat(startDatetime), timezone === '' ? "DTEND:".concat(endDatetime) : "DTEND;TZID=".concat(timezone, ":").concat(endDatetime), "SUMMARY:".concat(title), "DESCRIPTION:".concat(escapeICSDescription(description)), "LOCATION:".concat(location), 'END:VEVENT', 'END:VCALENDAR']).join('\n');
   return isMobile() ? encodeURI("data:text/calendar;charset=utf8,".concat(content)) : content;
 };
 /**
@@ -152,6 +163,8 @@ var buildShareUrl = function buildShareUrl(_ref4, type) {
       startDatetime = _ref4.startDatetime,
       _ref4$timezone = _ref4.timezone,
       timezone = _ref4$timezone === void 0 ? '' : _ref4$timezone,
+      _ref4$vtimezone = _ref4.vtimezone,
+      vtimezone = _ref4$vtimezone === void 0 ? '' : _ref4$vtimezone,
       _ref4$title = _ref4.title,
       title = _ref4$title === void 0 ? '' : _ref4$title;
   var encodeURI = type !== _enums.SHARE_SITES.ICAL && type !== _enums.SHARE_SITES.OUTLOOK;
@@ -162,6 +175,7 @@ var buildShareUrl = function buildShareUrl(_ref4, type) {
     location: encodeURI ? encodeURIComponent(location) : location,
     startDatetime: formatDate(startDatetime),
     timezone: timezone,
+    vtimezone: vtimezone,
     title: encodeURI ? encodeURIComponent(title) : title
   };
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -92,11 +92,15 @@ const buildShareFile = ({
   location = '',
   startDatetime,
   timezone = '',
+  vtimezone = '',
   title = '',
 }) => {
+  const vtimezoneTrimmed = vtimezone && vtimezone.replace(/^\s+/, '').replace(/\s+$/, '')
+
   let content = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
+    ...(vtimezoneTrimmed ? [vtimezoneTrimmed] : []),
     'BEGIN:VEVENT',
     `URL:${document.URL}`,
     'METHOD:PUBLISH',
@@ -132,6 +136,7 @@ export const buildShareUrl = ({
     location = '',
     startDatetime,
     timezone = '',
+    vtimezone = '',
     title = ''
   },
   type,
@@ -145,6 +150,7 @@ export const buildShareUrl = ({
     location: encodeURI ? encodeURIComponent(location) : location,
     startDatetime: formatDate(startDatetime),
     timezone,
+    vtimezone,
     title: encodeURI ? encodeURIComponent(title) : title,
   };
 

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -20,11 +20,26 @@ const testEvent = {
   title: 'Super Fun Event',
 }
 
+const testEventWithTimezone = {
+  ...testEvent,
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+}
+
+const testEventWithVTIMEZONE = {
+  ...testEventWithTimezone,
+  vtimezone: 'BEGIN:VTIMEZONE\nTZID:Europe/Dublin\nX-LIC-LOCATION:Europe/Dublin\nLAST-MODIFIED:20230517T170335Z\nBEGIN:STANDARD\nTZNAME:IST\nTZOFFSETFROM:+0000\nTZOFFSETTO:+0100\nDTSTART:19700329T010000\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\nEND:STANDARD\nBEGIN:DAYLIGHT\nTZNAME:GMT\nTZOFFSETFROM:+0100\nTZOFFSETTO:+0000\nDTSTART:19701025T020000\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\nEND:DAYLIGHT\nEND:VTIMEZONE\n'
+}
+
 const expectedOutputs = {
   google: 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20150126T000000Z/20150126T020000Z&location=NYC&text=Super%20Fun%20Event&details=Description%20of%20event.%20Going%20to%20have%20a%20lot%20of%20fun%20doing%20things%20that%20we%20scheduled%20ahead%20of%20time.',
+  googleWithTimezone: 'https://calendar.google.com/calendar/render?action=TEMPLATE&dates=20150126T000000Z/20150126T020000Z&ctz=America/Vancouver&location=NYC&text=Super%20Fun%20Event&details=Description%20of%20event.%20Going%20to%20have%20a%20lot%20of%20fun%20doing%20things%20that%20we%20scheduled%20ahead%20of%20time.',
   yahoo: 'https://calendar.yahoo.com/?v=60&view=d&type=20&title=Super%20Fun%20Event&st=20150126T000000Z&dur=0200&desc=Description%20of%20event.%20Going%20to%20have%20a%20lot%20of%20fun%20doing%20things%20that%20we%20scheduled%20ahead%20of%20time.&in_loc=NYC',
   ics: 'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:http://localhost/\nMETHOD:PUBLISH\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR',
+  icsWithTimezone: 'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:http://localhost/\nMETHOD:PUBLISH\nDTSTART;TZID=America/Vancouver:20150126T000000Z\nDTEND;TZID=America/Vancouver:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR',
+  icsWithVTIMEZONE: 'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VTIMEZONE\nTZID:Europe/Dublin\nX-LIC-LOCATION:Europe/Dublin\nLAST-MODIFIED:20230517T170335Z\nBEGIN:STANDARD\nTZNAME:IST\nTZOFFSETFROM:+0000\nTZOFFSETTO:+0100\nDTSTART:19700329T010000\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\nEND:STANDARD\nBEGIN:DAYLIGHT\nTZNAME:GMT\nTZOFFSETFROM:+0100\nTZOFFSETTO:+0000\nDTSTART:19701025T020000\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\nEND:DAYLIGHT\nEND:VTIMEZONE\nBEGIN:VEVENT\nURL:http://localhost/\nMETHOD:PUBLISH\nDTSTART;TZID=America/Vancouver:20150126T000000Z\nDTEND;TZID=America/Vancouver:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR',
   icsMobile: 'data:text/calendar;charset=utf8,BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:http://localhost/\nMETHOD:PUBLISH\nDTSTART:20150126T000000Z\nDTEND:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR',
+  icsMobileWithTimezone: 'data:text/calendar;charset=utf8,BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nURL:http://localhost/\nMETHOD:PUBLISH\nDTSTART;TZID=America/Vancouver:20150126T000000Z\nDTEND;TZID=America/Vancouver:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR',
+  icsMobileWithVTIMEZONE: 'data:text/calendar;charset=utf8,BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VTIMEZONE\nTZID:Europe/Dublin\nX-LIC-LOCATION:Europe/Dublin\nLAST-MODIFIED:20230517T170335Z\nBEGIN:STANDARD\nTZNAME:IST\nTZOFFSETFROM:+0000\nTZOFFSETTO:+0100\nDTSTART:19700329T010000\nRRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\nEND:STANDARD\nBEGIN:DAYLIGHT\nTZNAME:GMT\nTZOFFSETFROM:+0100\nTZOFFSETTO:+0000\nDTSTART:19701025T020000\nRRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\nEND:DAYLIGHT\nEND:VTIMEZONE\nBEGIN:VEVENT\nURL:http://localhost/\nMETHOD:PUBLISH\nDTSTART;TZID=America/Vancouver:20150126T000000Z\nDTEND;TZID=America/Vancouver:20150126T020000Z\nSUMMARY:Super Fun Event\nDESCRIPTION:Description of event. Going to have a lot of fun doing things that we scheduled ahead of time.\nLOCATION:NYC\nEND:VEVENT\nEND:VCALENDAR',
 }
 
 describe('formatDate', () => {
@@ -53,6 +68,16 @@ describe('buildShareUrl', () => {
       const result = buildShareUrl(testEvent, SHARE_SITES.GOOGLE);
       expect(result).toEqual(expectedOutputs.google);
     });
+
+    it('Google share URL includes timezone', () => {
+      const result = buildShareUrl(testEventWithTimezone, SHARE_SITES.GOOGLE);
+      expect(result).toEqual(expectedOutputs.googleWithTimezone);
+    });
+
+    it('Google share URL ignores VTIMEZONE', () => {
+      const result = buildShareUrl(testEventWithVTIMEZONE, SHARE_SITES.GOOGLE);
+      expect(result).toEqual(expectedOutputs.googleWithTimezone);
+    });
   });
 
   describe('Yahoo', () => {
@@ -68,6 +93,16 @@ describe('buildShareUrl', () => {
       }, SHARE_SITES.YAHOO);
       expect(result).toEqual(expectedOutputs.yahoo);
     });
+
+    it('Yahoo share URL ignores timezone', () => {
+      const result = buildShareUrl(testEventWithTimezone, SHARE_SITES.YAHOO);
+      expect(result).toEqual(expectedOutputs.yahoo);
+    });
+
+    it('Yahoo share URL ignores VTIMEZONE', () => {
+      const result = buildShareUrl(testEventWithVTIMEZONE, SHARE_SITES.YAHOO);
+      expect(result).toEqual(expectedOutputs.yahoo);
+    });
   });
 
 
@@ -77,6 +112,16 @@ describe('buildShareUrl', () => {
       expect(result).toEqual(expectedOutputs.ics);
     });
 
+    it('returns a proper iCal content object with timezone', () => {
+      const result = buildShareUrl(testEventWithTimezone, SHARE_SITES.ICAL);
+      expect(result).toEqual(expectedOutputs.icsWithTimezone);
+    });
+
+    it('returns a proper iCal content object with VTIMEZONE', () => {
+      const result = buildShareUrl(testEventWithVTIMEZONE, SHARE_SITES.ICAL);
+      expect(result).toEqual(expectedOutputs.icsWithVTIMEZONE);
+    });
+
     it('prepends a data URL when userAgent is mobile', () => {
       navigator.__defineGetter__('userAgent', function () {
         return "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
@@ -84,6 +129,24 @@ describe('buildShareUrl', () => {
 
       const result = buildShareUrl(testEvent, SHARE_SITES.ICAL);
       expect(result).toEqual(encodeURI(expectedOutputs.icsMobile));
+    });
+
+    it('prepends a data URL when userAgent is mobile with timezone', () => {
+      navigator.__defineGetter__('userAgent', function () {
+        return "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
+      });
+
+      const result = buildShareUrl(testEventWithTimezone, SHARE_SITES.ICAL);
+      expect(result).toEqual(encodeURI(expectedOutputs.icsMobileWithTimezone));
+    });
+
+    it('prepends a data URL when userAgent is mobile with VTIMEZONE', () => {
+      navigator.__defineGetter__('userAgent', function () {
+        return "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
+      });
+
+      const result = buildShareUrl(testEventWithVTIMEZONE, SHARE_SITES.ICAL);
+      expect(result).toEqual(encodeURI(expectedOutputs.icsMobileWithVTIMEZONE));
     });
   });
 });


### PR DESCRIPTION
Hello, first off thank you for the library, it's been very useful to us.

We've been running into the issue described at https://github.com/jasonleibowitz/react-add-to-calendar-hoc/issues/46 which results in `.ics` files generated by this library being imported into Outlook with start and end times 1 hour offset from what they should be. Updating these `.ics` files to include a VTIMEZONE component following [the spec](https://www.rfc-editor.org/rfc/rfc5545#page-65) fixes the issue for us.

I see that an abandoned PR to build VTIMEZONE functionality into react-add-to-calendar-hoc has been closed here: https://github.com/jasonleibowitz/react-add-to-calendar-hoc/pull/45

This kind of functionality would be ideal for us, but in lieu of that we can resolve our issue if we simply have an option to _insert_ pre-constructed VTIMEZONE text into the right place during react-add-to-calendar-hoc's `buildShareFile`. This pull request implements the logic needed to insert the VTIMEZONE component in the right place in the `.ics` file.

We're using https://github.com/add2cal/timezones-ical-library along with this glue code to integrate the two libraries:
```javascript
import { tzlib_get_ical_block, tzlib_get_timezones } from 'timezones-ical-library';

const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
const vtimezoneOptions = tzlib_get_timezones();
let [vtimezone = null] = vtimezoneOptions.includes(timezone) ? tzlib_get_ical_block(timezone) : [];
// tzlib uses \r\n as newline characters which we don't want, replace them with \n here:
vtimezone = vtimezone?.replace(/\r\n/g, '\n');

const AddToCalendarDropdown = AddToCalendarHOC(Button, Dropdown);
return (
  <AddToCalendarDropdown event={{ timezone, vtimezone, /* ...etc... */ }} />
);
```

